### PR TITLE
chore: rename project to function-aws-importer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,5 @@ endif
 	go generate ./...
 	docker build . --tag=runtime
 	rm package/*.xpkg; crossplane xpkg build -f package --embed-runtime-image=runtime
-	crossplane xpkg push -f package/*.xpkg $(FUNCTION_REGISTRY)/function-aws-resource-observer:dev
+	crossplane xpkg push -f package/*.xpkg $(FUNCTION_REGISTRY)/function-aws-importer:dev
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# function-aws-resource-observer
+# function-aws-importer
 
 A Crossplane Composition Function that automatically imports existing resources to Crossplane even if their external-name
 is non-deterministic, like in EC2 Security Groups, Route53 Hosted Zones, etc.
@@ -34,7 +34,7 @@ importing happens:
 ```yaml
 - step: import-sg-if-exists
   functionRef:
-   name: function-aws-resource-observer
+   name: function-aws-importer
   input:
    apiVersion: aws.fn.gympass.com/v1beta1
    kind: Observer
@@ -77,7 +77,7 @@ spec:
           toFieldPath: spec.forProvider.tags[crossplane.io/external-name]
    - step: import-sg-if-exists
      functionRef:
-        name: function-aws-resource-observer
+        name: function-aws-importer
      input:
         apiVersion: aws.fn.gympass.com/v1beta1
         kind: Observer

--- a/example/composition.yaml
+++ b/example/composition.yaml
@@ -106,7 +106,7 @@ spec:
           [[- end ]]
   - step: import-sg-if-exists
     functionRef:
-      name: function-aws-resource-observer
+      name: function-aws-importer
     input:
       resourceName: securityGroup
   - step: automatically-detect-ready-composed-resources

--- a/example/functions.yaml
+++ b/example/functions.yaml
@@ -2,13 +2,13 @@
 apiVersion: pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
-  name: function-aws-resource-observer
+  name: function-aws-importer
   annotations:
     # This tells crossplane beta render to connect to the function locally.
     render.crossplane.io/runtime: Development
 spec:
   # This is ignored when using the Development runtime.
-  package: function-aws-resource-observer
+  package: function-aws-importer
 ---
 apiVersion: pkg.crossplane.io/v1beta1
 kind: Function

--- a/fn.go
+++ b/fn.go
@@ -17,7 +17,7 @@ import (
 	"github.com/crossplane/function-sdk-go/resource"
 	"github.com/crossplane/function-sdk-go/response"
 
-	"github.com/gympass/function-aws-resource-observer/input/v1beta1"
+	"github.com/gympass/function-aws-importer/input/v1beta1"
 )
 
 const (

--- a/fn_test.go
+++ b/fn_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	"github.com/gympass/function-aws-resource-observer/input/v1beta1"
+	"github.com/gympass/function-aws-importer/input/v1beta1"
 )
 
 var _ resourcegroupstaggingapi.GetResourcesAPIClient = &mockGetResourcesAPIClient{}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gympass/function-aws-resource-observer
+module github.com/gympass/function-aws-importer
 
 go 1.21
 

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -2,6 +2,6 @@
 apiVersion: meta.pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
-  name: function-aws-resource-observer
+  name: function-aws-importer
 spec:
-  package: placeholder/function-aws-resource-observer:v0.0.1
+  package: placeholder/function-aws-importer:v0.0.1


### PR DESCRIPTION
So that it better represents what this actually does. It never observes any resources, it filters and observe resource tags with the objective of importing the resources it finds.

"Importing" is used in the same sense as this doc: https://docs.crossplane.io/latest/guides/import-existing-resources/