### PR TITLE
fix: only look for AWS managed resources

### DIFF
--- a/fn_test.go
+++ b/fn_test.go
@@ -39,6 +39,17 @@ func (s *functionSuite) req() *fnv1.RunFunctionRequest {
 		Input: resource.MustStructObject(s.in),
 		Desired: &fnv1.State{
 			Resources: map[string]*fnv1.Resource{
+				"someXR": {Resource: resource.MustStructJSON(`
+					{
+						"apiVersion": "acme.io/v1beta1",
+						"kind": "XSomeResource",
+						"metadata": {
+							"name": "test"
+						},
+						"spec": {
+							"deletionPolicy": "Orphan"
+                        }
+                    }`)},
 				"securityGroup": {Resource: resource.MustStructJSON(`
 					{
 						"apiVersion": "ec2.aws.upbound.io/v1beta1",
@@ -122,6 +133,17 @@ func (s *functionSuite) reqWithObservedExternalName(externalName string) *fnv1.R
 		Input: resource.MustStructObject(s.in),
 		Desired: &fnv1.State{
 			Resources: map[string]*fnv1.Resource{
+				"someXR": {Resource: resource.MustStructJSON(`
+					{
+						"apiVersion": "acme.io/v1beta1",
+						"kind": "XSomeResource",
+						"metadata": {
+							"name": "test"
+						},
+						"spec": {
+							"deletionPolicy": "Orphan"
+                        }
+                    }`)},
 				"securityGroup": {Resource: resource.MustStructJSON(`
 					{
 						"apiVersion": "ec2.aws.upbound.io/v1beta1",
@@ -199,6 +221,17 @@ func (s *functionSuite) reqWithObservedExternalName(externalName string) *fnv1.R
 		},
 		Observed: &fnv1.State{
 			Resources: map[string]*fnv1.Resource{
+				"someXR": {Resource: resource.MustStructJSON(`
+					{
+						"apiVersion": "acme.io/v1beta1",
+						"kind": "XSomeResource",
+						"metadata": {
+							"name": "test"
+						},
+						"spec": {
+							"deletionPolicy": "Orphan"
+                        }
+                    }`)},
 				"securityGroup": {Resource: resource.MustStructJSON(`
 					{
 						"apiVersion": "ec2.aws.upbound.io/v1beta1",
@@ -594,7 +627,11 @@ func (s *functionSuite) TestRunFunction_AllExternalNamesAreSetAlready_ShouldEnsu
 			GetFields()["tags"].GetStructValue().
 			GetFields()[externalNameTag].GetStringValue()
 
-		s.Equal("some-external-name", got)
+		if isManagedResource := r.Resource.GetFields()["apiVersion"].GetStringValue() != "acme.io/v1beta1"; isManagedResource {
+			s.Equal("some-external-name", got)
+		} else {
+			s.Empty(got)
+		}
 	}
 }
 

--- a/internal/zz_taggable.go
+++ b/internal/zz_taggable.go
@@ -273,6 +273,8 @@ var taggableGroupKinds = map[string]bool{
 	"subnetgroup.docdb.aws.upbound.io":                                     true,
 	"directory.ds.aws.m.upbound.io":                                        true,
 	"directory.ds.aws.upbound.io":                                          true,
+	"cluster.dsql.aws.m.upbound.io":                                        true,
+	"cluster.dsql.aws.upbound.io":                                          true,
 	"tablereplica.dynamodb.aws.m.upbound.io":                               true,
 	"table.dynamodb.aws.m.upbound.io":                                      true,
 	"tablereplica.dynamodb.aws.upbound.io":                                 true,


### PR DESCRIPTION
The function previously attempted to handle all composed resources, which of course isn't always valid. Composed resources might be XRs (which don't have external names) or MRs from other providers (which we can't discover using AWS).